### PR TITLE
webdataset bugfixes, optional wandb logging for VAE training, VQGAN discriminator warmup + spectral norm

### DIFF
--- a/pl_dalle/loader.py
+++ b/pl_dalle/loader.py
@@ -68,7 +68,7 @@ class ImageDataModule(LightningDataModule):
         else:
             if self.web_dataset:
                 DATASET_TRAIN = web_dataset_helper(self.train_dir)
-                #DATASET_VAL = web_dataset_helper(self.val_dir)
+                DATASET_VAL = web_dataset_helper(self.val_dir)
                 DATASET_SIZE = int(1e9)
                 BATCH_SIZE = self.batch_size
                 
@@ -83,16 +83,15 @@ class ImageDataModule(LightningDataModule):
                     .map_tuple(self.transform_train)
                     .batched(BATCH_SIZE, partial=False) # It is good to avoid partial batches when using Distributed training
                     )  
-                '''
+
                 self.val_dataset = (
-                    wds.webdataset(dataset_val,length=num_batches)
+                    wds.webdataset(DATASET_VAL, length=num_batches)
                     # .shuffle(is_shuffle) # commented out for webdataset as the behaviour cannot be predicted yet
                     .decode("pil")
                     .to_tuple("jpg;png;jpeg cls")
                     .map_tuple(self.transform_val, identity)
                     .batched(BATCH_SIZE, partial=False) # It is good to avoid partial batches when using Distributed training
                     )                                     
-                '''
             else:
                 self.train_dataset = ImageFolder(self.train_dir, self.transform_train)
                 self.val_dataset = ImageFolder(self.val_dir, self.transform_val)
@@ -102,7 +101,7 @@ class ImageDataModule(LightningDataModule):
         if self.web_dataset:
             return wds.WebLoader(self.train_dataset, batch_size=None, num_workers=self.num_workers)
         else:
-            return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers,shuffle=True)
+            return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True)
 
     def val_dataloader(self):
         if self.web_dataset:
@@ -210,19 +209,13 @@ class TextImageDataModule(LightningDataModule):
                                         )
     def train_dataloader(self):
         if self.web_dataset:
-            return wds.WebLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers,shuffle=True)
+            return wds.WebLoader(self.train_dataset, batch_size=None, num_workers=self.num_workers, shuffle=True)
         else:
-            return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers,shuffle=True)
+            return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True)
 
     def val_dataloader(self):
         if self.web_dataset:
-            return wds.WebLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
-        else:
-            return DataLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
-
-    def val_dataloader(self):
-        if self.web_dataset:
-            return wds.WebLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
+            return wds.WebLoader(self.val_dataset, batch_size=None, num_workers=self.num_workers)
         else:
             return DataLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
 

--- a/pl_dalle/loader.py
+++ b/pl_dalle/loader.py
@@ -27,7 +27,7 @@ def web_dataset_helper(path):
         DATASET = path
         print('Found WebDataset .tar(.gz) file under given path {}!'.format(path))
     else:
-        raise Exception('No folder, no .tar(.gz) and no url pointing to tar files provided under {}.'.format(args.image_text_folder))
+        raise Exception('No folder, no .tar(.gz) and no url pointing to tar files provided under {}.'.format(path))
     return DATASET
 
 def identity(x):
@@ -68,28 +68,31 @@ class ImageDataModule(LightningDataModule):
         else:
             if self.web_dataset:
                 DATASET_TRAIN = web_dataset_helper(self.train_dir)
-                DATASET_VAL = web_dataset_helper(self.val_dir)
+                #DATASET_VAL = web_dataset_helper(self.val_dir)
                 DATASET_SIZE = int(1e9)
                 BATCH_SIZE = self.batch_size
                 
                 num_batches = DATASET_SIZE // BATCH_SIZE
 
                 self.train_dataset = (
-                    wds.WebDataset(DATASET_TRAIN, length=num_batches)
+                    wds.WebDataset(DATASET_TRAIN, length=num_batches, #cache_dir="./cache"
+                    )
                     # .shuffle(is_shuffle) # Commented out for WebDataset as the behaviour cannot be predicted yet
                     .decode("pil")
-                    .to_tuple("jpg;png;jpeg cls")
-                    .map_tuple(self.transform_train, identity)
+                    .to_tuple("jpg;png;jpeg")
+                    .map_tuple(self.transform_train)
                     .batched(BATCH_SIZE, partial=False) # It is good to avoid partial batches when using Distributed training
                     )  
+                '''
                 self.val_dataset = (
-                    wds.WebDataset(DATASET_VAL,length=num_batches)
-                    # .shuffle(is_shuffle) # Commented out for WebDataset as the behaviour cannot be predicted yet
+                    wds.webdataset(dataset_val,length=num_batches)
+                    # .shuffle(is_shuffle) # commented out for webdataset as the behaviour cannot be predicted yet
                     .decode("pil")
                     .to_tuple("jpg;png;jpeg cls")
                     .map_tuple(self.transform_val, identity)
                     .batched(BATCH_SIZE, partial=False) # It is good to avoid partial batches when using Distributed training
                     )                                     
+                '''
             else:
                 self.train_dataset = ImageFolder(self.train_dir, self.transform_train)
                 self.val_dataset = ImageFolder(self.val_dir, self.transform_val)
@@ -97,19 +100,13 @@ class ImageDataModule(LightningDataModule):
 
     def train_dataloader(self):
         if self.web_dataset:
-            return wds.WebLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers,shuffle=True)
+            return wds.WebLoader(self.train_dataset, batch_size=None, num_workers=self.num_workers)
         else:
             return DataLoader(self.train_dataset, batch_size=self.batch_size, num_workers=self.num_workers,shuffle=True)
 
     def val_dataloader(self):
         if self.web_dataset:
-            return wds.WebLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
-        else:
-            return DataLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
-
-    def val_dataloader(self):
-        if self.web_dataset:
-            return wds.WebLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
+            return wds.WebLoader(self.val_dataset, batch_size=None, num_workers=self.num_workers)
         else:
             return DataLoader(self.val_dataset, batch_size=self.batch_size, num_workers=self.num_workers)
 

--- a/pl_dalle/modules/discriminator/model.py
+++ b/pl_dalle/modules/discriminator/model.py
@@ -62,6 +62,11 @@ class NLayerDiscriminator(nn.Module):
             nn.Conv2d(ndf * nf_mult, 1, kernel_size=kw, stride=1, padding=padw)]  # output 1 channel prediction map
         self.main = nn.Sequential(*sequence)
 
+        for module in self.modules():
+            if isinstance(module, (nn.Conv2d, nn.Linear)):
+                module = nn.utils.spectral_norm(module)
+
+
     def forward(self, input):
         """Standard forward."""
         return self.main(input)

--- a/pl_dalle/modules/losses/vqperceptual.py
+++ b/pl_dalle/modules/losses/vqperceptual.py
@@ -13,6 +13,8 @@ class DummyLoss(nn.Module):
 
 def adopt_weight(weight, global_step, threshold=0, value=0.):
     if global_step < threshold:
+        # diff = global_step - threshold
+        # weight = weight * exp(diff / 1e4)
         weight = value
     return weight
 
@@ -117,6 +119,6 @@ class VQLPIPSWithDiscriminator(nn.Module):
                 logits_real = self.discriminator(torch.cat((inputs.contiguous().detach(), cond), dim=1))
                 logits_fake = self.discriminator(torch.cat((reconstructions.contiguous().detach(), cond), dim=1))
 
-            disc_factor = adopt_weight(self.disc_factor, global_step, threshold=self.discriminator_iter_start)
+            disc_factor = self.disc_factor # adopt_weight(self.disc_factor, global_step, threshold=self.discriminator_iter_start)
             d_loss = disc_factor * self.disc_loss(logits_real, logits_fake)
             return d_loss

--- a/pl_dalle/modules/losses/vqperceptual.py
+++ b/pl_dalle/modules/losses/vqperceptual.py
@@ -13,8 +13,6 @@ class DummyLoss(nn.Module):
 
 def adopt_weight(weight, global_step, threshold=0, value=0.):
     if global_step < threshold:
-        # diff = global_step - threshold
-        # weight = weight * exp(diff / 1e4)
         weight = value
     return weight
 

--- a/train_vae.py
+++ b/train_vae.py
@@ -3,6 +3,7 @@ import numpy as np
 import random
 from PIL import Image
 import torch
+import wandb
 
 
 # vision imports
@@ -21,6 +22,7 @@ from pytorch_lightning import seed_everything
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import XLAStatsMonitor
 from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
+from pytorch_lightning.loggers import WandbLogger
 
 
 
@@ -233,12 +235,16 @@ if __name__ == "__main__":
         
 
     else:
+        logger = WandbLogger(project='vqgan', log_model='all')
         trainer = Trainer(tpu_cores=tpus, gpus= gpus, default_root_dir=default_root_dir,
                           max_epochs=args.epochs, progress_bar_refresh_rate=args.refresh_rate,precision=args.precision,
-                          accelerator='ddp',
+                          accelerator='ddp', benchmark=True,
                           num_sanity_val_steps=args.num_sanity_val_steps,
                           limit_train_batches=limit_train_batches,limit_test_batches=limit_test_batches,                          
-                          resume_from_checkpoint = ckpt_path)
+                          resume_from_checkpoint = ckpt_path,
+                          logger = logger,
+          )
+        logger.watch(model)
 
     if args.backup:
         trainer.callbacks.append(backup_callback)                                 


### PR DESCRIPTION
Had a bunch of pieces that I wanted to change for my personal VQGAN training run, not sure if you want all of them but I'm pretty sure they're all positive.

For VQGAN, hinge loss means that there's not much reason not to train the discriminator in the early steps, before we start to backprop it through the generator, especially since we're going to do the forward passes anyway with the way the current training loop is set up. I also added spectral normalization to the discriminator, to keep the discriminator-induced gradients from exploding too hard.

The other changes are more strictly positive - there were some bugs in webdataset loading leading to input being batches of batches instead of just, well, batches. These changes might need some additional patching to support conditional generators / discriminators, though since the original code didn't work at all I still see this as a strict improvement.

I also added optional wandb logging, which is conditionally imported only if the --wandb argument is passed to train_vae.py, which both logs gradients of the VQGAN and logs reconstructed images in a table instead of in separate grids.